### PR TITLE
Hide mines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .vscode/
+logger.txt

--- a/game.py
+++ b/game.py
@@ -198,11 +198,17 @@ class Game:
         """
         Creates the labels used in the tracking frame.
         """
+        mine_label = tk.Label(master=self.tracking_frame, text="Mine Count")
+        mine_count = tk.Label(master=self.tracking_frame, text=self.m_count)
+        mine_label.pack()
+        mine_count.pack()
+
         sus_label = tk.Label(master=self.tracking_frame, text="Suspected")
         sus_count = tk.Label(master=self.tracking_frame, text=self.sus)
-        win_label = tk.Label(master=self.tracking_frame, text="Spaces Remaining")
-        win_count = tk.Label(master=self.tracking_frame, text=self.non_mine_count)
         sus_label.pack()
         sus_count.pack()
+
+        win_label = tk.Label(master=self.tracking_frame, text="Spaces Remaining")
+        win_count = tk.Label(master=self.tracking_frame, text=self.non_mine_count)
         win_label.pack()
         win_count.pack()

--- a/game.py
+++ b/game.py
@@ -1,10 +1,15 @@
 # This module contains an abstraction for the game.
 
 from board import Board
-from mine import MineError
+from mine import MineError, Mine
 import tkinter as tk
 import logging
 
+logging.basicConfig(
+    level=logging.INFO,
+    filename="./logger.txt",
+    format="%(asctime)s; %(levelname)s: %(message)s"
+)
 
 class Game:
 
@@ -28,6 +33,9 @@ class Game:
         Updates the win_countdown and sus counts and then 
         redraws the tracking_frame to display info to user.
         """
+        if isinstance(event.widget, Mine):
+            return
+
         # update sus and win counts
         self.__set_blank_space_count()
         self.sus = 0
@@ -47,11 +55,22 @@ class Game:
         self.tracking_frame.pack()
 
 
-    def play_game(self):
+    def __reveal_board(self):
+        """
+        Loops through all spaces on board and reveals what they
+        were by calling the reveal method. To be used when a user
+        clicks on a mine.
+        """
+        for row in self.board.board:
+            for space in row:
+                space.reveal()
+
+
+    def play_game(self, event=None):
         """
         Creates a new game in tkinter and launches game loop.
         """
-
+        self.log.info("Starting a new game...")
         self.__set_new_game()
 
         # start the game
@@ -64,9 +83,12 @@ class Game:
         that are raised when a user clicks a mine. Default
         is to log the error message.
         """
+        self.log.info(f"exception type: {x_type}, val: {x_val}")
         if isinstance(x_val, MineError):
-            return self.play_game()
-        self.log.log(x_type)
+            restart = tk.Button(master=self.tracking_frame, text="RESTART?")
+            restart.bind("<Button-1>", self.play_game, "+")
+            restart.pack()
+            self.__reveal_board()
 
 
     def __set_new_game(self):

--- a/mine.py
+++ b/mine.py
@@ -14,9 +14,13 @@ class Mine(Space):
     def put_on_board(self):
         super().put_on_board()
         self.bind("<Button-1>", self.__select)
-        self.config(background="black")
         self.grid(row=self.row, column=self.col)
 
 
     def __select(self, event):
+        """
+        Changes background to black to signify mine
+        and raises MineError.
+        """
+        self.config(background=self.bg_color)
         raise MineError

--- a/mine.py
+++ b/mine.py
@@ -19,8 +19,6 @@ class Mine(Space):
 
     def __select(self, event):
         """
-        Changes background to black to signify mine
-        and raises MineError.
+        Raises MineError to be caught by game.
         """
-        self.config(background=self.sel_color)
         raise MineError

--- a/mine.py
+++ b/mine.py
@@ -5,7 +5,7 @@ class MineError(Exception):
     pass
 
 class Mine(Space):
-    bg_color = "black"
+    sel_color = "black"
     
     def __init__(self, row, col, board) -> None:
         super().__init__(row, col, board)
@@ -22,5 +22,5 @@ class Mine(Space):
         Changes background to black to signify mine
         and raises MineError.
         """
-        self.config(background=self.bg_color)
+        self.config(background=self.sel_color)
         raise MineError

--- a/space.py
+++ b/space.py
@@ -54,7 +54,14 @@ class Space(Button):
         if not self.selected:
             self.suspected = False
             self.selected = True
-            self.config(background=self.sel_color, text=self.display_text)
+            self.reveal()
+
+
+    def reveal(self):
+        """
+        Reveals the space by changing background to approp color.
+        """
+        self.config(background=self.sel_color, text=self.display_text)
 
 
     def __toggle_suspect(self, event):


### PR DESCRIPTION
Implemented functionality as follows:
* Added mine count to tracker on RHS
* Hide the mines until a user clicks on one
* Once a user clicks on one, reveal all mines spaces and display a restart button
* Added a logger to log exceptions and keep them off of stdout

To do still with future branches:
* Implement difficulty choice with GUI instead of CLI
* Make window resizable